### PR TITLE
fix: キャッシュ処理の修正

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -199,7 +199,7 @@ def get_search_tweets(illust_id: str):
     illust_url = result["illust"]["image_urls"]["large"]
 
     # 画像をダウンロード
-    path = pixiv_download(illust_url, illust_id)
+    path = pixiv_download(illust_url, result["illust"]["type"], illust_id)
 
     screen_names = get_illust_screen_names(pixiv_api, result["illust"])
     if len(screen_names) == 0:

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -16,7 +16,7 @@ from PIL import Image
 TOKEN_FILE = os.environ.setdefault('PIXIVPY_TOKEN_FILE', '/data/token.json')
 CONFIG_FILE = os.environ.setdefault('CONFIG_FILE', '/data/config.json')
 VIEWED_FILE = os.environ.setdefault('VIEWED_FILE', '/data/viewed.json')
-ILLUST_CACHE_DIR = os.environ.setdefault('IMAGE_CACHE_DIR', '/cache/illusts/')
+ILLUST_CACHE_DIR = os.environ.setdefault('ILLUST_CACHE_DIR', '/cache/illusts/')
 NOVEL_CACHE_DIR = os.environ.setdefault('NOVEL_CACHE_DIR', '/cache/novels/')
 MANGA_CACHE_DIR = os.environ.setdefault('MANGA_CACHE_DIR', '/cache/manga/')
 IMAGE_CACHE_DIR = os.environ.setdefault('IMAGE_CACHE_DIR', '/cache/images/')
@@ -65,8 +65,15 @@ def init_pixiv_api():
 
 
 def pixiv_download(url: str,
-                   illust_id: str):
-    path = os.path.join(IMAGE_CACHE_DIR, illust_id, url.split("/")[-1])
+                   item_type: str,
+                   item_id: str):
+    size_regex = re.compile(r"\d+x\d+")
+    page_regex = re.compile(r"p\d+")
+    size = size_regex.search(url).group(0)
+    extension = url.split(".")[-1]
+    page = None if page_regex.search(url) is None else page_regex.search(url).group(0)
+    filename = size + ("" if page is None else "-" + page) + "." + extension
+    path = os.path.join(IMAGE_CACHE_DIR, item_type, item_id, filename)
     os.makedirs(os.path.dirname(path), exist_ok=True)
 
     if os.path.exists(path):
@@ -176,8 +183,9 @@ def like_pixiv(item_type: str,
 
 
 def get_image(url: str,
-              illust_id: str):
-    path = pixiv_download(url, illust_id)
+              item_type: str,
+              item_id: str):
+    path = pixiv_download(url, item_type, item_id)
     return FileResponse(path, media_type="image/png")
 
 

--- a/api/endpoints/images.py
+++ b/api/endpoints/images.py
@@ -5,6 +5,6 @@ from api import get_image
 router = APIRouter(prefix="/images")
 
 
-@router.get("/{illust_id}")
-def get_image_req(illust_id: str, url: str):
-    return get_image(url, illust_id)
+@router.get("/{item_type}/{item_id}")
+def get_image_req(item_type: str, item_id: str, url: str):
+    return get_image(url, item_type, item_id)

--- a/view/src/plugins/fetcher.ts
+++ b/view/src/plugins/fetcher.ts
@@ -97,17 +97,38 @@ export class Fetcher {
   }
 
   private itemProcessor(item: PixivItem) {
-    item.image_urls.large = `${this.$config.baseURL}api/images/${item.id}?url=${item.image_urls.large}`
-    item.image_urls.medium = `${this.$config.baseURL}api/images/${item.id}?url=${item.image_urls.medium}`
-    item.image_urls.square_medium = `${this.$config.baseURL}api/images/${item.id}?url=${item.image_urls.square_medium}`
+    item.image_urls.large = this.convertImageUrl(item, item.image_urls.large)
+    item.image_urls.medium = this.convertImageUrl(item, item.image_urls.medium)
+    item.image_urls.square_medium = this.convertImageUrl(
+      item,
+      item.image_urls.square_medium
+    )
 
     if (this.targetType === 'ILLUST' || this.targetType === 'MANGA') {
       for (const metaPage of item.meta_pages) {
-        metaPage.image_urls.large = `${this.$config.baseURL}api/images/${item.id}?url=${metaPage.image_urls.large}`
-        metaPage.image_urls.medium = `${this.$config.baseURL}api/images/${item.id}?url=${metaPage.image_urls.medium}`
-        metaPage.image_urls.square_medium = `${this.$config.baseURL}api/images/${item.id}?url=${metaPage.image_urls.square_medium}`
+        metaPage.image_urls.large = this.convertImageUrl(
+          item,
+          metaPage.image_urls.large
+        )
+        metaPage.image_urls.medium = this.convertImageUrl(
+          item,
+          metaPage.image_urls.medium
+        )
+        metaPage.image_urls.square_medium = this.convertImageUrl(
+          item,
+          metaPage.image_urls.square_medium
+        )
       }
     }
+  }
+
+  private convertImageUrl(item: PixivItem, url: string) {
+    return [
+      `${this.$config.baseURL}api`,
+      'images',
+      this.targetType.toLocaleLowerCase(),
+      `${item.id}?url=${url}`,
+    ].join('/')
   }
 
   private isFilterItem(target: Target | null, item: PixivItem) {


### PR DESCRIPTION
- close #120 

---

- `ILLUST_CACHE_DIR` で読み取るべき環境変数のキーが間違っていた
- pixivからキャッシュしたイラストなどの画像データのキャッシュキーの変更
  - 従来: pixivが付与する画像URLのファイル名
  - 今後: `アイテム種別(illust/manga/novel)`/`アイテムID`/`画像解像度`-`(pページ数)`.`拡張子`
    - ページ数およびページ数前のハイフンはマンガの場合のみ付与
- 画像URLの変換処理をまともにした