### PR TITLE
feat: 個別アイテムのミュート設定を追加

### DIFF
--- a/api/endpoints/__init__.py
+++ b/api/endpoints/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from api.endpoints import illust, images, like, manga, novel, recommended, settings_sync, tweet, viewed
+from api.endpoints import illust, manga, novel, search, images, like, recommended, settings_sync, tweet, user, viewed
 
 router = APIRouter(prefix="/api")
 
@@ -10,11 +10,13 @@ def get_root():
     return {"message": "my-pixiv api"}
 
 
+router.include_router(search.router)
 router.include_router(illust.router)
-router.include_router(images.router)
-router.include_router(like.router)
 router.include_router(manga.router)
 router.include_router(novel.router)
+router.include_router(images.router)
+router.include_router(user.router)
+router.include_router(like.router)
 router.include_router(tweet.router)
 router.include_router(viewed.router)
 router.include_router(settings_sync.router)

--- a/api/endpoints/illust.py
+++ b/api/endpoints/illust.py
@@ -1,10 +1,10 @@
 from fastapi import APIRouter
 
-from api import get_pixiv
+from api import get_pixiv_item
 
 router = APIRouter(prefix="/illust")
 
 
-@router.get("/{word}")
-def get_illusts_req(word: str):
-    return get_pixiv("illust", word)
+@router.get("/{item_id}")
+def get_illust_req(item_id: str):
+    return get_pixiv_item("illust", item_id)

--- a/api/endpoints/manga.py
+++ b/api/endpoints/manga.py
@@ -1,10 +1,10 @@
 from fastapi import APIRouter
 
-from api import get_pixiv
+from api import get_pixiv_item
 
 router = APIRouter(prefix="/manga")
 
 
-@router.get("/{word}")
-def get_novels_req(word: str):
-    return get_pixiv("manga", word)
+@router.get("/{item_id}")
+def get_manga_req(item_id: str):
+    return get_pixiv_item("manga", item_id)

--- a/api/endpoints/novel.py
+++ b/api/endpoints/novel.py
@@ -1,10 +1,10 @@
 from fastapi import APIRouter
 
-from api import get_pixiv
+from api import get_pixiv_item
 
 router = APIRouter(prefix="/novel")
 
 
-@router.get("/{word}")
-def get_novels_req(word: str):
-    return get_pixiv("novel", word)
+@router.get("/{item_id}")
+def get_novel_req(item_id: str):
+    return get_pixiv_item("novel", item_id)

--- a/api/endpoints/search.py
+++ b/api/endpoints/search.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter
+
+from api import search_pixiv
+
+router = APIRouter(prefix="/search")
+
+
+@router.get("/illust/{word}")
+def get_illusts_req(word: str):
+    return search_pixiv("illust", word)
+
+
+@router.get("/novel/{word}")
+def get_novels_req(word: str):
+    return search_pixiv("novel", word)
+
+
+@router.get("/manga/{word}")
+def get_manga_req(word: str):
+    return search_pixiv("manga", word)

--- a/api/endpoints/user.py
+++ b/api/endpoints/user.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+
+from api import get_pixiv_item
+
+router = APIRouter(prefix="/user")
+
+
+@router.get("/{item_id}")
+def get_user_req(item_id: str):
+    return get_pixiv_item("user", item_id)

--- a/scripts/server-dev.ps1
+++ b/scripts/server-dev.ps1
@@ -7,9 +7,11 @@ pip install -r requirements.txt
 $env:PIXIVPY_TOKEN_FILE = "data/token.json"
 $env:CONFIG_FILE = "data/config.json"
 $env:VIEWED_FILE = "data/viewed.json"
-$env:IMAGE_CACHE_DIR = "cache/illusts/"
+$env:IMAGE_CACHE_DIR = "cache/images/"
+$env:ILLUST_CACHE_DIR = "cache/illusts/"
 $env:MANGA_CACHE_DIR = "cache/mangas/"
 $env:NOVEL_CACHE_DIR = "cache/novels/"
+$env:USER_CACHE_DIR = "cache/users/"
 $env:IMAGE_CACHE_DIR = "cache/images/"
 $env:TWEET_CACHE_DIR = "cache/tweets/"
 

--- a/view/nuxt.config.ts
+++ b/view/nuxt.config.ts
@@ -77,6 +77,7 @@ const config: NuxtConfig = {
     { src: '@/plugins/settings', ssr: false },
     { src: '@/plugins/fetcher', ssr: false },
     { src: '@/plugins/viewedSync', ssr: false },
+    { src: '@/plugins/vue-long-click', mode: 'client' },
   ],
 
   components: true,

--- a/view/package.json
+++ b/view/package.json
@@ -48,6 +48,7 @@
     "stylelint-config-recommended-vue": "1.4.0",
     "stylelint-config-standard": "28.0.0",
     "typed-vuex": "0.3.1",
+    "vue-long-click": "0.1.0",
     "vuex": "4.0.2",
     "vuex-persistedstate": "4.1.0",
     "websocket-ts": "1.1.1"

--- a/view/src/components/IllustList.vue
+++ b/view/src/components/IllustList.vue
@@ -9,6 +9,7 @@
       @open="open"
       @intersect-item="onItemViewing"
       @load-more="loadMore"
+      @add-mute="addMute"
     ></ItemList>
     <v-dialog
       v-model="overlay.isIllustOpened"
@@ -95,6 +96,7 @@ export default Vue.extend({
           this.$config,
           this.$axios,
           this.$accessor.settings.filters,
+          this.$accessor.settings.muted,
           this.targetType
         )
       }
@@ -147,6 +149,16 @@ export default Vue.extend({
         return
       }
       this.$accessor.viewed.addIllust(item)
+    },
+    addMute(item: PixivItem) {
+      if (!confirm(`「${item.title}」をミュートしますか？`)) {
+        return
+      }
+      this.$accessor.settings.addMuteItem({
+        targetType: 'ILLUST',
+        targetId: item.id,
+      })
+      this.items = this.items.filter((i) => i.id !== item.id)
     },
   },
 })

--- a/view/src/components/IllustPopup.vue
+++ b/view/src/components/IllustPopup.vue
@@ -11,6 +11,10 @@
         <v-icon>mdi-heart</v-icon>
       </v-btn>
 
+      <v-btn icon @click="addMute()">
+        <v-icon>mdi-image-remove-outline</v-icon>
+      </v-btn>
+
       <v-btn icon :color="getTweetFoundColor()" @click="openTwitter()">
         <v-icon>mdi-twitter</v-icon>
       </v-btn>
@@ -160,6 +164,20 @@ export default Vue.extend({
         return ''
       }
       return this.isTweetFound ? 'primary' : 'error'
+    },
+    addMute() {
+      if (!this.item) {
+        return
+      }
+      if (!confirm('このイラストをミュートしますか？')) {
+        return
+      }
+
+      this.$accessor.settings.addMuteItem({
+        targetType: 'ILLUST',
+        targetId: this.item.id,
+      })
+      this.$emit('close-popup')
     },
     addHeart() {
       if (this.item == null) {

--- a/view/src/components/IllustPopup.vue
+++ b/view/src/components/IllustPopup.vue
@@ -50,6 +50,10 @@
         <v-icon>mdi-heart</v-icon>
       </v-btn>
 
+      <v-btn icon @click="addMute()">
+        <v-icon>mdi-image-remove-outline</v-icon>
+      </v-btn>
+
       <v-btn icon :color="getTweetFoundColor()" @click="openTwitter()">
         <v-icon>mdi-twitter</v-icon>
       </v-btn>

--- a/view/src/components/ItemCard.vue
+++ b/view/src/components/ItemCard.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/no-v-html -->
 <template>
-  <v-card @click="open(item)">
+  <v-card v-longclick="() => addMute()" @click="open(item)">
     <div
       class="d-flex flex-no-wrap justify-space-between"
       style="height: 200px"
@@ -74,6 +74,10 @@ export default Vue.extend({
     },
     open(item: PixivItem): void {
       this.$emit('open', item)
+    },
+    addMute(): void {
+      console.log('addMute')
+      this.$emit('add-mute', this.item)
     },
     copyToClipboard(text: string) {
       const textarea = document.createElement('textarea')

--- a/view/src/components/ItemList.vue
+++ b/view/src/components/ItemList.vue
@@ -9,6 +9,7 @@
       @open="open"
       @intersect-item="onItemViewing"
       @load-more="loadMore"
+      @add-mute="addMute"
     />
     <ItemVirtualList
       v-if="type === 'VIRTUAL_SCROLL'"
@@ -19,6 +20,7 @@
       @open="open"
       @intersect-item="onItemViewing"
       @load-more="loadMore"
+      @add-mute="addMute"
     />
     <ItemGridList
       v-if="type === 'GRID_LIST'"
@@ -29,6 +31,7 @@
       @open="open"
       @intersect-item="onItemViewing"
       @load-more="loadMore"
+      @add-mute="addMute"
     />
   </div>
 </template>
@@ -70,6 +73,9 @@ export default Vue.extend({
     },
     loadMore(): void {
       this.$emit('load-more')
+    },
+    addMute(item: PixivItem): void {
+      this.$emit('add-mute', item)
     },
   },
 })

--- a/view/src/components/ItemPaginationList.vue
+++ b/view/src/components/ItemPaginationList.vue
@@ -29,6 +29,7 @@
             :item="item"
             :is-viewed="vieweds !== undefined && !isViewed(item)"
             @open="open"
+            @add-mute="addMute"
           />
         </ItemWrapper>
       </v-col>
@@ -121,6 +122,9 @@ export default Vue.extend({
     },
     open(item: PixivItem): void {
       this.$emit('open', item)
+    },
+    addMute(item: PixivItem): void {
+      this.$emit('add-mute', item)
     },
     onItemViewing(item: PixivItem): void {
       this.$emit('intersect-item', item)

--- a/view/src/components/ItemVirtualList.vue
+++ b/view/src/components/ItemVirtualList.vue
@@ -27,6 +27,7 @@
                 :is-viewed="vieweds !== undefined && !isViewed(item)"
                 @open="open"
                 @intersect="onItemViewing"
+                @add-mute="addMute"
               />
             </ItemWrapper>
           </v-col>
@@ -95,6 +96,9 @@ export default Vue.extend({
     },
     onItemViewing(item: PixivItem): void {
       this.$emit('intersect-item', item)
+    },
+    addMute(item: PixivItem): void {
+      this.$emit('add-mute', item)
     },
     isViewed(item: PixivItem): boolean {
       if (!this.vieweds) {

--- a/view/src/components/NovelList.vue
+++ b/view/src/components/NovelList.vue
@@ -9,6 +9,7 @@
       @open="open"
       @intersect-item="onItemViewing"
       @load-more="loadMore"
+      @add-mute="addMute"
     ></ItemList>
   </v-container>
 </template>
@@ -70,6 +71,7 @@ export default Vue.extend({
           this.$config,
           this.$axios,
           this.$accessor.settings.filters,
+          this.$accessor.settings.muted,
           'NOVEL'
         )
       }
@@ -138,6 +140,18 @@ export default Vue.extend({
         return
       }
       this.$accessor.viewed.addNovel(item)
+    },
+    addMute(item: PixivItem) {
+      if (
+        !confirm(`「${item.title} (${item.user.name})」をミュートしますか？`)
+      ) {
+        return
+      }
+      this.$accessor.settings.addMuteItem({
+        targetType: 'NOVEL',
+        targetId: item.id,
+      })
+      this.items = this.items.filter((i) => i.id !== item.id)
     },
   },
 })

--- a/view/src/components/settings/MutedItemSettings.vue
+++ b/view/src/components/settings/MutedItemSettings.vue
@@ -1,0 +1,283 @@
+<template>
+  <v-container>
+    <h2>アイテムミュート設定</h2>
+
+    <v-btn color="success" block class="ma-3" @click="isOpen = true"
+      >設定を開く</v-btn
+    >
+
+    <v-dialog v-model="isOpen" fullscreen transition="dialog-bottom-transition">
+      <v-card v-if="isOpen">
+        <v-toolbar flat dark color="primary">
+          <v-btn icon dark @click="isOpen = false">
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+          <v-toolbar-title>ミュート設定</v-toolbar-title>
+        </v-toolbar>
+
+        <v-card-title>ミュート対象に追加</v-card-title>
+
+        <v-card-text>
+          <v-form ref="addForm">
+            <v-select
+              v-model="targetType"
+              :items="targetTypes"
+              item-text="name"
+              item-value="key"
+              return-object
+              label="アイテム種別"
+            ></v-select>
+            <v-text-field
+              v-model="targetId"
+              label="ミュート対象のアイテムID"
+              placeholder="例: 1234567890"
+              :rules="[(v) => !!v || '必須項目です']"
+              @blur="checkUrl()"
+            ></v-text-field>
+            <v-btn color="success" block @click="add()">追加</v-btn>
+          </v-form>
+        </v-card-text>
+
+        <v-card-title>ミュート対象一覧</v-card-title>
+
+        <v-card-text>
+          <v-pagination
+            v-model="page"
+            :length="pageCount"
+            circle
+          ></v-pagination>
+
+          <v-list>
+            <v-list-item
+              v-for="(item, i) of getItems()"
+              :key="i"
+              @click="open(item)"
+            >
+              <v-list-item-icon>
+                <v-icon>{{ getTypeIcon(item.targetType) }}</v-icon>
+              </v-list-item-icon>
+
+              <v-list-item-content v-if="item.detail">
+                <v-list-item-title v-if="item.targetType !== 'USER'"
+                  >{{ item.detail.title }}
+                </v-list-item-title>
+                <v-list-item-title v-else
+                  >{{ item.detail.name }}
+                </v-list-item-title>
+
+                <v-list-item-subtitle v-if="item.targetType !== 'USER'">
+                  {{ getTypeName(item.targetType) }} ―
+                  {{ item.detail.user.name }}</v-list-item-subtitle
+                >
+                <v-list-item-subtitle v-else>
+                  {{ item.detail.id }}</v-list-item-subtitle
+                >
+              </v-list-item-content>
+              <v-list-item-content v-else-if="item.detail === undefined">
+                <v-list-item-title>読み込み中</v-list-item-title>
+                <v-list-item-subtitle>
+                  {{ getTypeName(item.targetType) }} ―
+                  {{ item.targetId }}</v-list-item-subtitle
+                >
+              </v-list-item-content>
+              <v-list-item-content v-else>
+                <v-list-item-title>読み込み失敗</v-list-item-title>
+                <v-list-item-subtitle>
+                  {{ getTypeName(item.targetType) }} ―
+                  {{ item.targetId }}</v-list-item-subtitle
+                >
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-btn icon @click="remove(item)">
+                  <v-icon>mdi-close</v-icon>
+                </v-btn>
+              </v-list-item-action>
+            </v-list-item>
+          </v-list>
+
+          <v-pagination
+            v-model="page"
+            :length="pageCount"
+            circle
+          ></v-pagination>
+        </v-card-text>
+      </v-card>
+    </v-dialog>
+  </v-container>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { PixivItem } from '@/types/pixivItem'
+import { MuteItem, MuteTargetType } from '@/store/settings'
+
+const targetsMap: {
+  [key in MuteTargetType]: string
+} = {
+  ILLUST: 'イラスト・マンガ',
+  NOVEL: '小説',
+  USER: 'ユーザー',
+}
+
+type Item = MuteItem & {
+  detail?: PixivItem | null
+}
+
+export default Vue.extend({
+  name: 'MutedItemSettings',
+  data(): {
+    isOpen: boolean
+    targetId: string
+    targetType: { key: string; name: string }
+    targetTypes: { key: string; name: string }[]
+    page: number
+    pageCount: number
+    items: Item[]
+  } {
+    return {
+      isOpen: false,
+      targetId: '',
+      targetType: {
+        key: 'ILLUST',
+        name: 'イラスト・マンガ',
+      },
+      targetTypes: Object.keys(targetsMap).map((key) => ({
+        key,
+        name: targetsMap[key as MuteTargetType],
+      })),
+      page: 1,
+      pageCount: 1,
+      items: [],
+    }
+  },
+  mounted() {
+    this.fetch()
+  },
+  methods: {
+    fetch() {
+      this.items = this.$accessor.settings.muted
+    },
+    add() {
+      if (
+        !(
+          this.$refs.addForm as unknown as {
+            validate: () => boolean
+          }
+        ).validate()
+      ) {
+        return
+      }
+      if (
+        this.items.some(
+          (item) =>
+            item.targetId === parseInt(this.targetId) &&
+            item.targetType === this.targetType.key
+        )
+      ) {
+        alert('既に追加されています')
+        return
+      }
+      this.$accessor.settings.addMuteItem({
+        targetType: this.targetType.key as MuteTargetType,
+        targetId: parseInt(this.targetId),
+      })
+      this.targetId = ''
+      this.targetType = {
+        key: 'ILLUST',
+        name: 'イラスト・マンガ',
+      }
+
+      this.fetch()
+    },
+    remove(item: Item) {
+      this.$accessor.settings.removeMuteItem(item)
+      this.fetch()
+    },
+    open(item: Item) {
+      switch (item.targetType) {
+        case 'ILLUST':
+          window.open(
+            `https://www.pixiv.net/artworks/${item.targetId}`,
+            '_blank'
+          )
+          break
+        case 'NOVEL':
+          window.open(
+            `https://www.pixiv.net/novel/show.php?id=${item.targetId}`,
+            '_blank'
+          )
+          break
+        case 'USER':
+          window.open(`https://www.pixiv.net/users/${item.targetId}`, '_blank')
+          break
+      }
+    },
+    getItems(): Item[] {
+      const items = this.items.slice((this.page - 1) * 10, this.page * 10)
+      for (const item of items) {
+        if (item.detail !== undefined || item.detail === null) {
+          continue
+        }
+        this.$axios
+          .get(`/api/${item.targetType.toLocaleLowerCase()}/${item.targetId}`)
+          .then((res) => {
+            this.items = this.items.map((i) =>
+              i.targetId === item.targetId ? { ...i, detail: res.data } : i
+            )
+          })
+          .catch((err) => {
+            this.items = this.items.map((i) => {
+              if (i.targetId === item.targetId) {
+                i.detail = null
+              }
+              return i
+            })
+            console.error(err)
+          })
+      }
+      return items
+    },
+    getTypeName(type: MuteTargetType): string {
+      return targetsMap[type]
+    },
+    getTypeIcon(type: MuteTargetType): string {
+      switch (type) {
+        case 'ILLUST':
+          return 'mdi-image'
+        case 'NOVEL':
+          return 'mdi-book-open-page-variant'
+        case 'USER':
+          return 'mdi-account'
+      }
+    },
+    checkUrl() {
+      const illustUrlRegex = /https:\/\/www\.pixiv\.net\/artworks\/(\d+)/
+      const novelUrlRegex =
+        /https:\/\/www\.pixiv\.net\/novel\/show\.php\?id=(\d+)/
+      const userUrlRegex = /https:\/\/www\.pixiv\.net\/users\/(\d+)/
+      const illustUrlMatch = illustUrlRegex.exec(this.targetId)
+      const novelUrlMatch = novelUrlRegex.exec(this.targetId)
+      const userUrlMatch = userUrlRegex.exec(this.targetId)
+      if (illustUrlMatch) {
+        this.targetType = {
+          key: 'ILLUST',
+          name: 'イラスト・マンガ',
+        }
+        this.targetId = illustUrlMatch[1]
+      } else if (novelUrlMatch) {
+        this.targetType = {
+          key: 'NOVEL',
+          name: '小説',
+        }
+        this.targetId = novelUrlMatch[1]
+      } else if (userUrlMatch) {
+        this.targetType = {
+          key: 'USER',
+          name: 'ユーザー',
+        }
+        this.targetId = userUrlMatch[1]
+      }
+    },
+  },
+})
+</script>

--- a/view/src/pages/settings.vue
+++ b/view/src/pages/settings.vue
@@ -5,6 +5,7 @@
     <PaginationSettings />
     <TitleFilter />
     <TagFilter />
+    <MutedItemSettings />
     <ImportExportForm />
     <SyncSettings />
   </v-container>
@@ -19,6 +20,7 @@ import ImportExportForm from '@/components/settings/ImportExportForm.vue'
 import ViewTypeSelector from '@/components/settings/ViewTypeSelector.vue'
 import SyncSettings from '@/components/settings/SyncSettings.vue'
 import PaginationSettings from '@/components/settings/PaginationSettings.vue'
+import MutedItemSettings from '@/components/settings/MutedItemSettings.vue'
 
 export default Vue.extend({
   name: 'SettingsPage',
@@ -30,6 +32,7 @@ export default Vue.extend({
     ImportExportForm,
     SyncSettings,
     PaginationSettings,
+    MutedItemSettings,
   },
 })
 </script>

--- a/view/src/plugins/vue-long-click.ts
+++ b/view/src/plugins/vue-long-click.ts
@@ -1,0 +1,4 @@
+import Vue from 'vue'
+import { longClickDirective } from 'vue-long-click'
+const longClickInstance = longClickDirective({ delay: 1000, interval: 500 })
+Vue.directive('longclick', longClickInstance)

--- a/view/src/store/settings.ts
+++ b/view/src/store/settings.ts
@@ -16,6 +16,13 @@ export interface Filter {
   value: string
 }
 
+export type MuteTargetType = 'ILLUST' | 'NOVEL' | 'USER'
+
+export interface MuteItem {
+  targetType: MuteTargetType
+  targetId: number
+}
+
 interface Settings {
   isDarkMode: boolean
   isOnlyNew: boolean
@@ -25,6 +32,7 @@ interface Settings {
   paginationLimit: number
   targets: Target[]
   filters: Filter[]
+  muted: MuteItem[]
 }
 
 export const state = (): Settings => ({
@@ -36,6 +44,7 @@ export const state = (): Settings => ({
   paginationLimit: 10,
   targets: [],
   filters: [],
+  muted: [],
 })
 
 export type RootState = ReturnType<typeof state>
@@ -55,6 +64,7 @@ export const getters = getterTree(state, {
     )
   },
   filters: (state) => state.filters,
+  muted: (state) => state.muted,
 })
 
 export const mutations = mutationTree(state, {
@@ -69,6 +79,7 @@ export const mutations = mutationTree(state, {
       state.novelViewType = settings.novelViewType
     if (settings.targets !== undefined) state.targets = settings.targets
     if (settings.filters !== undefined) state.filters = settings.filters
+    if (settings.muted !== undefined) state.muted = settings.muted
   },
   setDarkMode(state, isDarkMode: boolean) {
     state.isDarkMode = isDarkMode
@@ -93,6 +104,9 @@ export const mutations = mutationTree(state, {
   },
   setFilters(state, filters: Filter[]) {
     state.filters = filters
+  },
+  setMuted(state, muted: MuteItem[]) {
+    state.muted = muted
   },
 })
 
@@ -135,6 +149,19 @@ export const actions = actionTree(
         'setFilters',
         state.filters.filter(
           (f) => f.type !== filter.type || f.value !== filter.value
+        )
+      )
+    },
+    addMuteItem({ state, commit }, muteItem: MuteItem) {
+      commit('setMuted', [...state.muted, muteItem])
+    },
+    removeMuteItem({ state, commit }, muteItem: MuteItem) {
+      commit(
+        'setMuted',
+        state.muted.filter(
+          (m) =>
+            m.targetType !== muteItem.targetType ||
+            m.targetId !== muteItem.targetId
         )
       )
     },

--- a/view/src/types/vue-long-click.d.ts
+++ b/view/src/types/vue-long-click.d.ts
@@ -1,0 +1,1 @@
+declare module 'vue-long-click'

--- a/view/yarn.lock
+++ b/view/yarn.lock
@@ -10475,6 +10475,13 @@ vue-loader@^15.9.7:
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
 
+vue-long-click@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/vue-long-click/-/vue-long-click-0.1.0.tgz#e56fc94b33dccf8bffcf314a16341fbd311722a7"
+  integrity sha512-PNeVTwPmAlbsyPU46cSJBmpYIAxiMxlIw8rbumUm9Av/GiC15bw1KDPMckr8gsfEmwfloowdRfxtY9IY7ptzbw==
+  dependencies:
+    vue "^2.5.22"
+
 vue-meta@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/vue-meta/-/vue-meta-2.4.0.tgz#a419fb4b4135ce965dab32ec641d1989c2ee4845"
@@ -10527,7 +10534,7 @@ vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue@2.7.10, vue@^2.6.12:
+vue@2.7.10, vue@^2.5.22, vue@^2.6.12:
   version "2.7.10"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.7.10.tgz#ae516cc6c88e1c424754468844218fdd5e280f40"
   integrity sha512-HmFC70qarSHPXcKtW8U8fgIkF6JGvjEmDiVInTkKZP0gIlEPhlVlcJJLkdGIDiNkIeA2zJPQTWJUI4iWe+AVfg==


### PR DESCRIPTION
イラスト (マンガを含む)、小説、ユーザを対象とするアイテムのミュート設定を追加します。

- close #133

## 具体的な変更点

### ミュート設定の追加

スクリーンショットのようなミュート設定画面と機能を追加。
該当するアイテムはおすすめ・検索結果から排除される。

![image](https://user-images.githubusercontent.com/8929706/193457957-56b9033e-ec64-4b8c-865a-515496c7781a.png)

### アイテム長押しによるミュート（ページネーション・バーチャルスクロール）

おすすめ・検索結果に表示されるアイテムを長押しすることで対象アイテムのミュートが可能。ユーザミュートは設定画面からしか行えない。

### イラストポップアップにミュートアクションを追加

![image](https://user-images.githubusercontent.com/8929706/193458391-b9e22eeb-2b95-4b73-820a-1e0eb64fa991.png)

### 一部エンドポイントの変更

特定アイテムの情報取得エンドポイントが必要になったため、既存エンドポイントの変更と新規追加を実施。

- `/api/search/illust/{word}`: イラスト検索 (旧 `/api/illust/{word}`)
- `/api/search/manga/{word}`: イラスト検索 (旧 `/api/manga/{word}`)
- `/api/search/novel/{word}`: イラスト検索 (旧 `/api/novel/{word}`)
- `/api/illust/{item_id}`: 指定されたIDのイラスト・マンガ情報を取得
- `/api/novel/{item_id}`: 指定されたIDの小説情報を取得
- `/api/user/{item_id}`: 指定されたIDのユーザ情報を取得

