### PR TITLE
fix: クライアント開発用ps1を修正

### DIFF
--- a/scripts/client-dev.ps1
+++ b/scripts/client-dev.ps1
@@ -1,5 +1,5 @@
 Set-Location $PSScriptRoot
+Set-Location ..
 
-Set-Location ../view
-yarn
-yarn dev
+Start-Process -FilePath yarn -WorkingDirectory "view" -NoNewWindow -Wait
+Start-Process -FilePath yarn -ArgumentList "dev" -WorkingDirectory "view" -NoNewWindow -Wait


### PR DESCRIPTION
Ctrl+Cで終了したときにviewディレクトリ内に居るままになる問題解決